### PR TITLE
Fix crash when rapidly scrolling

### DIFF
--- a/roster/Classes/Views/AsyncLoadingImageView.swift
+++ b/roster/Classes/Views/AsyncLoadingImageView.swift
@@ -18,10 +18,13 @@ class AsyncLoadingImageView: UIImageView {
         image = .None
 
         currentRequest = NSURLSession.fetchDataFromURL(url) { data in
-            dispatch_main_async {
-                let newImage = UIImage(data: data)
-                self.image = newImage
-                ImageCache.cacheImage(newImage, forURL: url)
+            let newImage: UIImage? = UIImage(data: data)
+
+            if let returnedImage = newImage {
+                dispatch_main_async {
+                    self.image = returnedImage
+                    ImageCache.cacheImage(returnedImage, forURL: url)
+                }
             }
         }
 


### PR DESCRIPTION
If you scroll too fast, this can come back with `nil` data. If that happens,
`UIImage(data:)` will fail and return `nil` even though the type says that
shouldn't be possible. This is going to be the behavior with Swift 1.1 anyway,
so this is a bit of futureproofing as well.
